### PR TITLE
Add postrelease support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ It is made up of the following elements (which are given during instantiation):
 - ``package`` (required), the name of the package this ``Version`` represents.
 - ``major``, ``minor``, ``micro`` (all required), the X.Y.Z of your project's ``Version``.
 - ``release_candidate`` (optional), set to 0 or higher to mark this ``Version`` being of a release candidate (also sometimes called a "prerelease").
+- ``post`` (optional), set to 0 or higher to mark this ``Version`` as a postrelease.
 - ``dev`` (optional), set to 0 or higher to mark this ``Version`` as a development release.
 
 You can extract a PEP-440 compatible version string by using the following methods:
@@ -79,6 +80,7 @@ The commands that can be given after that will determine what the next version i
 - ``--rc``, to set the project version to ``<year-2000>.<month>.0rc1`` if the current version is not a release candidate, or bump the release candidate number by 1 if it is.
 - ``--dev``, to set the project development release number to 0 if it is not a development release, or bump the development release number by 1 if it is.
 - ``--patch``, to increment the patch number of the release. This will also reset the release candidate number, pass ``--rc`` at the same time to increment the patch number and make it a release candidate.
+- ``--post``, to set the project postrelease number to 0 if it is not a postrelease, or bump the postrelease number by 1 if it is. This will also reset the release candidate and development release numbers.
 
 If you give no arguments, it will strip the release candidate number, making it a "full release".
 

--- a/src/incremental/tests/test_update.py
+++ b/src/incremental/tests/test_update.py
@@ -50,8 +50,8 @@ next_released_version = "inctestpkg NEXT"
 
         out = []
         _run('inctestpkg', path=None, newversion=None, patch=False, rc=False,
-             dev=False, create=True, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=False, create=True, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertTrue(self.packagedir.child("_version.py").exists())
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
@@ -108,7 +108,7 @@ __all__ = ["__version__"]
         out = []
         with self.assertRaises(ValueError):
             _run(u'inctestpkg', path=None, newversion=None,
-                 patch=False, rc=False, dev=True, create=False,
+                 patch=False, rc=False, post=False, dev=True, create=False,
                  _date=self.date, _getcwd=self.getcwd, _print=out.append)
 
 
@@ -150,8 +150,8 @@ __all__ = ["__version__"]
         """
         out = []
         _run(u'inctestpkg', path=None, newversion=None,
-             patch=False, rc=False, dev=True, create=False, _date=self.date,
-             _getcwd=self.getcwd, _print=out.append)
+             patch=False, rc=False, post=False, dev=True, create=False,
+             _date=self.date, _getcwd=self.getcwd, _print=out.append)
 
         self.assertTrue(self.packagedir.child("_version.py").exists())
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
@@ -169,8 +169,8 @@ __all__ = ["__version__"]
 ''')
 
         _run(u'inctestpkg', path=None, newversion=None,
-             patch=False, rc=False, dev=True, create=False, _date=self.date,
-             _getcwd=self.getcwd, _print=out.append)
+             patch=False, rc=False, post=False, dev=True, create=False,
+             _date=self.date, _getcwd=self.getcwd, _print=out.append)
 
         self.assertTrue(self.packagedir.child("_version.py").exists())
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
@@ -226,8 +226,8 @@ __all__ = ["__version__"]
         """
         out = []
         _run(u'inctestpkg', path=self.packagedir.path, newversion=None,
-             patch=False, rc=False, dev=True, create=False, _date=self.date,
-             _print=out.append)
+             patch=False, rc=False, post=False, dev=True, create=False,
+             _date=self.date, _print=out.append)
 
         self.assertTrue(self.packagedir.child("_version.py").exists())
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
@@ -250,8 +250,8 @@ __all__ = ["__version__"]
         """
         out = []
         _run(u'inctestpkg', path=None, newversion=None, patch=False, rc=False,
-             dev=True, create=False, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=True, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertTrue(self.packagedir.child("_version.py").exists())
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
@@ -274,8 +274,8 @@ __all__ = ["__version__"]
         """
         out = []
         _run(u'inctestpkg', path=None, newversion=None, patch=True, rc=False,
-             dev=False, create=False, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
                          b'''"""
@@ -310,8 +310,8 @@ __all__ = ["__version__"]
 
         out = []
         _run(u'inctestpkg', path=None, newversion=None, patch=True, rc=False,
-             dev=False, create=False, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
                          b'''"""
@@ -334,8 +334,8 @@ __all__ = ["__version__"]
         """
         out = []
         _run(u'inctestpkg', path=None, newversion=None, patch=True, rc=True,
-             dev=False, create=False, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
                          b'''"""
@@ -370,8 +370,8 @@ __all__ = ["__version__"]
 
         out = []
         _run(u'inctestpkg', path=None, newversion=None, patch=False, rc=True,
-             dev=False, create=False, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
                          b'''"""
@@ -407,8 +407,8 @@ __all__ = ["__version__"]
 
         out = []
         _run(u'inctestpkg', path=None, newversion=None, patch=False, rc=True,
-             dev=False, create=False, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
                          b'''"""
@@ -437,8 +437,8 @@ next_released_version = "inctestpkg 16.8.0rc1"
         """
         out = []
         _run(u'inctestpkg', path=None, newversion=None, patch=False, rc=True,
-             dev=False, create=False, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
                          b'''"""
@@ -461,8 +461,8 @@ next_released_version = "inctestpkg 16.8.0rc1"
 """)
 
         _run(u'inctestpkg', path=None, newversion=None, patch=False, rc=False,
-             dev=False, create=False, _date=self.date, _getcwd=self.getcwd,
-             _print=out.append)
+             post=False, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
                          b'''"""
@@ -492,91 +492,51 @@ next_released_version = "inctestpkg 16.8.0"
         out = []
         with self.assertRaises(ValueError) as e:
             _run(u'inctestpkg', path=None, newversion=None, patch=False,
-                 rc=False, dev=False, create=False, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
+                 rc=False, post=False, dev=False, create=False,
+                 _date=self.date, _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(
             e.exception.args[0],
             "You need to issue a rc before updating the major/minor")
 
-    def test_no_mix_newversion(self):
+    def test_post(self):
         """
-        The `--newversion` flag can't be mixed with --patch, --rc, or --dev.
-        """
-        out = []
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion="1", patch=True,
-                 rc=False, dev=False, create=False, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --newversion")
-
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion="1", patch=False,
-                 rc=True, dev=False, create=False, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --newversion")
-
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion="1", patch=False,
-                 rc=False, dev=True, create=False, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --newversion")
-
-    def test_no_mix_dev(self):
-        """
-        The `--dev` flag can't be mixed with --patch, or --rc.
+        `incremental.update package --post` increments the post version.
         """
         out = []
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion=None, patch=True,
-                 rc=False, dev=True, create=False, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --dev")
+        _run(u'inctestpkg', path=None, newversion=None, patch=False, rc=False,
+             post=True, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
 
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion=None, patch=False,
-                 rc=True, dev=True, create=False, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --dev")
+        self.assertTrue(self.packagedir.child("_version.py").exists())
+        self.assertEqual(self.packagedir.child("_version.py").getContent(),
+                         b'''"""
+Provides inctestpkg version information.
+"""
 
-    def test_no_mix_create(self):
+# This file is auto-generated! Do not edit!
+# Use `python -m incremental.update inctestpkg` to change this file.
+
+from incremental import Version
+
+__version__ = Version('inctestpkg', 1, 2, 3, post=0)
+__all__ = ["__version__"]
+''')
+
+    def test_post_with_prerelease_and_dev(self):
         """
-        The `--create` flag can't be mixed with --patch, --rc, --dev, or
-        --newversion.
+        `incremental.update package --post` increments the post version, and
+        disregards any old prerelease/dev versions.
         """
+        self.packagedir.child('_version.py').setContent(b"""
+from incremental import Version
+__version__ = Version('inctestpkg', 1, 2, 3, release_candidate=1, dev=2)
+__all__ = ["__version__"]
+""")
+
         out = []
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion=None, patch=True,
-                 rc=False, dev=False, create=True, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --create")
-
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion="1", patch=False,
-                 rc=False, dev=False, create=True, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --create")
-
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion=None, patch=False,
-                 rc=True, dev=False, create=True, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --create")
-
-        with self.assertRaises(ValueError) as e:
-            _run(u'inctestpkg', path=None, newversion=None, patch=False,
-                 rc=False, dev=True, create=True, _date=self.date,
-                 _getcwd=self.getcwd, _print=out.append)
-        self.assertEqual(e.exception.args[0], "Only give --create")
-
-    def test_newversion(self):
-        """
-        `incremental.update package --newversion=1.2.3rc1dev3`, will set that
-        version in the package.
-        """
-        out = []
-        _run(u'inctestpkg', path=None, newversion="1.2.3rc1dev3", patch=False,
-             rc=False, dev=False, create=False, _date=self.date,
+        _run(u'inctestpkg', path=None, newversion=None, patch=False, rc=False,
+             post=True, dev=False, create=False, _date=self.date,
              _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),
@@ -589,15 +549,165 @@ Provides inctestpkg version information.
 
 from incremental import Version
 
-__version__ = Version('inctestpkg', 1, 2, 3, release_candidate=1, dev=3)
+__version__ = Version('inctestpkg', 1, 2, 3, post=0)
+__all__ = ["__version__"]
+''')
+
+    def test_post_with_existing_post(self):
+        """
+        `incremental.update package --post` increments the post version if the
+        existing version is an postrelease, and discards any dev version.
+        """
+        self.packagedir.child('_version.py').setContent(b"""
+from incremental import Version
+__version__ = Version('inctestpkg', 1, 2, 3, post=1, dev=2)
+__all__ = ["__version__"]
+""")
+
+        out = []
+        _run(u'inctestpkg', path=None, newversion=None, patch=False, rc=False,
+             post=True, dev=False, create=False, _date=self.date,
+             _getcwd=self.getcwd, _print=out.append)
+
+        self.assertEqual(self.packagedir.child("_version.py").getContent(),
+                         b'''"""
+Provides inctestpkg version information.
+"""
+
+# This file is auto-generated! Do not edit!
+# Use `python -m incremental.update inctestpkg` to change this file.
+
+from incremental import Version
+
+__version__ = Version('inctestpkg', 1, 2, 3, post=2)
+__all__ = ["__version__"]
+''')
+        self.assertEqual(self.packagedir.child("__init__.py").getContent(),
+                         b"""
+from incremental import Version
+introduced_in = Version('inctestpkg', 1, 2, 3, post=2).short()
+next_released_version = "inctestpkg 1.2.3post2"
+""")
+
+    def test_no_mix_newversion(self):
+        """
+        The `--newversion` flag can't be mixed with --patch, --rc, --post,
+        or --dev.
+        """
+        out = []
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion="1", patch=True,
+                 rc=False, post=False, dev=False, create=False,
+                 _date=self.date, _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --newversion")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion="1", patch=False,
+                 rc=True, post=False, dev=False, create=False,
+                 _date=self.date, _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --newversion")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion="1", patch=False,
+                 rc=False, post=True, dev=False, create=False,
+                 _date=self.date, _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --newversion")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion="1", patch=False,
+                 rc=False, post=False, dev=True, create=False,
+                 _date=self.date, _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --newversion")
+
+    def test_no_mix_dev(self):
+        """
+        The `--dev` flag can't be mixed with --patch, --rc, or --post.
+        """
+        out = []
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion=None, patch=True,
+                 rc=False, post=False, dev=True, create=False, _date=self.date,
+                 _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --dev")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion=None, patch=False,
+                 rc=True, post=False, dev=True, create=False, _date=self.date,
+                 _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --dev")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion=None, patch=False,
+                 rc=False, post=True, dev=True, create=False, _date=self.date,
+                 _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --dev")
+
+    def test_no_mix_create(self):
+        """
+        The `--create` flag can't be mixed with --patch, --rc, --post,
+        --dev, or --newversion.
+        """
+        out = []
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion=None, patch=True,
+                 rc=False, post=False, dev=False, create=True, _date=self.date,
+                 _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --create")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion="1", patch=False,
+                 rc=False, post=False, dev=False, create=True, _date=self.date,
+                 _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --create")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion=None, patch=False,
+                 rc=True, post=False, dev=False, create=True, _date=self.date,
+                 _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --create")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion=None, patch=False,
+                 rc=False, post=True, dev=False, create=True, _date=self.date,
+                 _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --create")
+
+        with self.assertRaises(ValueError) as e:
+            _run(u'inctestpkg', path=None, newversion=None, patch=False,
+                 rc=False, post=False, dev=True, create=True, _date=self.date,
+                 _getcwd=self.getcwd, _print=out.append)
+        self.assertEqual(e.exception.args[0], "Only give --create")
+
+    def test_newversion(self):
+        """
+        `incremental.update package --newversion=1.2.3rc1post2dev3`, will
+        set that version in the package.
+        """
+        out = []
+        _run(u'inctestpkg', path=None, newversion="1.2.3rc1post2dev3",
+             patch=False, rc=False, post=False, dev=False, create=False,
+             _date=self.date, _getcwd=self.getcwd, _print=out.append)
+
+        self.assertEqual(self.packagedir.child("_version.py").getContent(),
+                         b'''"""
+Provides inctestpkg version information.
+"""
+
+# This file is auto-generated! Do not edit!
+# Use `python -m incremental.update inctestpkg` to change this file.
+
+from incremental import Version
+
+__version__ = Version('inctestpkg', 1, 2, 3, '''
+                       b'''release_candidate=1, post=2, dev=3)
 __all__ = ["__version__"]
 ''')
         self.assertEqual(self.packagedir.child("__init__.py").getContent(),
                          (b"""
 from incremental import Version
 introduced_in = Version('inctestpkg', 1, 2, 3, """
-                         b"""release_candidate=1, dev=3).short()
-next_released_version = "inctestpkg 1.2.3rc1dev3"
+                         b"""release_candidate=1, post=2, dev=3).short()
+next_released_version = "inctestpkg 1.2.3rc1post2dev3"
 """))
 
     def test_newversion_bare(self):
@@ -607,7 +717,7 @@ next_released_version = "inctestpkg 1.2.3rc1dev3"
         """
         out = []
         _run(u'inctestpkg', path=None, newversion="1", patch=False,
-             rc=False, dev=False, create=False, _date=self.date,
+             rc=False, post=False, dev=False, create=False, _date=self.date,
              _getcwd=self.getcwd, _print=out.append)
 
         self.assertEqual(self.packagedir.child("_version.py").getContent(),

--- a/src/incremental/tests/test_update.py
+++ b/src/incremental/tests/test_update.py
@@ -699,7 +699,7 @@ Provides inctestpkg version information.
 from incremental import Version
 
 __version__ = Version('inctestpkg', 1, 2, 3, '''
-                       b'''release_candidate=1, post=2, dev=3)
+                         b'''release_candidate=1, post=2, dev=3)
 __all__ = ["__version__"]
 ''')
         self.assertEqual(self.packagedir.child("__init__.py").getContent(),

--- a/src/incremental/update.py
+++ b/src/incremental/update.py
@@ -53,7 +53,7 @@ def _existing_version(path):
     return version_info["__version__"]
 
 
-def _run(package, path, newversion, patch, rc, dev, create,
+def _run(package, path, newversion, patch, rc, post, dev, create,
          _date=None, _getcwd=None, _print=print):
 
     if not _getcwd:
@@ -70,14 +70,15 @@ def _run(package, path, newversion, patch, rc, dev, create,
     else:
         path = FilePath(path)
 
-    if newversion and patch or newversion and dev or newversion and rc:
+    if newversion and patch or newversion and dev or newversion and rc or \
+       newversion and post:
         raise ValueError("Only give --newversion")
 
-    if dev and patch or dev and rc:
+    if dev and patch or dev and rc or dev and post:
         raise ValueError("Only give --dev")
 
     if create and dev or create and patch or create and rc or \
-       create and newversion:
+       create and post or create and newversion:
         raise ValueError("Only give --create")
 
     if newversion:
@@ -95,6 +96,7 @@ def _run(package, path, newversion, patch, rc, dev, create,
         v = Version(
             package, *release,
             release_candidate=st_version.pre[1] if st_version.pre else None,
+            post=st_version.post[1] if st_version.post else None,
             dev=st_version.dev[1] if st_version.dev else None)
 
     elif create:
@@ -119,6 +121,17 @@ def _run(package, path, newversion, patch, rc, dev, create,
         existing = _existing_version(path)
         v = Version(package, existing.major, existing.minor,
                     existing.micro + 1, rc)
+
+    elif post:
+        existing = _existing_version(path)
+
+        if existing.post is None:
+            _post = 0
+        else:
+            _post = existing.post + 1
+
+        v = Version(package, existing.major, existing.minor,
+                    existing.micro, post=_post)
 
     elif dev:
         existing = _existing_version(path)
@@ -199,6 +212,7 @@ def _run(package, path, newversion, patch, rc, dev, create,
 @click.option('--newversion', default=None)
 @click.option('--patch', is_flag=True)
 @click.option('--rc', is_flag=True)
+@click.option('--post', is_flag=True)
 @click.option('--dev', is_flag=True)
 @click.option('--create', is_flag=True)
 def run(*args, **kwargs):


### PR DESCRIPTION
This is somewhat related to #29.

My own motivation is that we have a temporary local fork of an old version of Twisted in Launchpad, currently versioned `13.0.0-p2`, and as part of trying to convert from buildout to pip (which is a prerequisite for upgrading to a modern Twisted, for tedious reasons) I discovered that the version we have isn't PEP 440-compliant.  That caused me to look into whether Twisted's current versioning code supported PEP 440 postreleases, and discovered that it doesn't; hence this PR.