### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   matrix:
     - TOX_ENV=py27-flake8
     - TOX_ENV=py27-tests
-    - TOX_ENV=py33-tests
     - TOX_ENV=py34-tests
     - TOX_ENV=apidocs
     - TOX_ENV=check-manifest

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-import os, sys
+import os
+import sys
 
 from setuptools import setup, find_packages
 
@@ -20,14 +21,12 @@ setup(
     maintainer='Amber Brown',
     maintainer_email='hawkowl@twistedmatrix.com',
     url="https://github.com/twisted/incremental",
-    classifiers = [
+    classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tests/test_exampleproj.py
+++ b/tests/test_exampleproj.py
@@ -9,6 +9,7 @@ from __future__ import division, absolute_import
 
 from twisted.trial.unittest import TestCase
 
+
 class ExampleProjTests(TestCase):
 
     def test_version(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py27,py35}-flake8,
-    {py27,pypy,py33,py34,py35,py36}-tests,
+    {py27,pypy,py34,py35,py36}-tests,
     check-manifest,
     apidocs
 


### PR DESCRIPTION
Python 2.6 and 3.3 are both EOL and no longer receiving security or any other updates from the core Python team.

They're also little used.

Here's the pip installs for incremental from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  77.11% |        223,638 |
| 3.6            |  13.11% |         38,011 |
| 3.5            |   6.99% |         20,258 |
| 3.4            |   2.41% |          6,981 |
| 3.7            |   0.22% |            635 |
| 3.3            |   0.11% |            321 |
| 2.6            |   0.05% |            146 |
| 3.2            |   0.01% |             20 |
| None           |   0.00% |              9 |
| 3.8            |   0.00% |              2 |

Source: `pypinfo --start-date -41 --end-date -14 --percent --pip --markdown incremental pyversion`

Additionally, Python 3.3 is failing the CI build.