### PR TITLE
Fix build for forks

### DIFF
--- a/.travis/build_docs.sh
+++ b/.travis/build_docs.sh
@@ -10,7 +10,7 @@ if [[ ${TRAVIS_PULL_REQUEST} == "false" ]] && [[ ${TRAVIS_BRANCH} == "master" ]]
     tox -e apidocs
 
     # Make the directory
-    git clone --branch gh-pages https://github.com/hawkowl/incremental.git /tmp/tmp-docs
+    git clone --branch gh-pages https://github.com/twisted/incremental.git /tmp/tmp-docs
 
     # Copy the docs
     rsync -rt --del --exclude=".git" apidocs/* /tmp/tmp-docs/docs/
@@ -34,7 +34,7 @@ if [[ ${TRAVIS_PULL_REQUEST} == "false" ]] && [[ ${TRAVIS_BRANCH} == "master" ]]
     if [[ ${TRAVIS_REPO_SLUG} == "twisted/incremental" ]];
     then
       # Push it up
-      git push -q "https://${GH_TOKEN}@github.com/hawkowl/incremental.git" gh-pages
+      git push -q "https://${GH_TOKEN}@github.com/twisted/incremental.git" gh-pages
     fi
 else
     echo "skipping docs upload"

--- a/.travis/build_docs.sh
+++ b/.travis/build_docs.sh
@@ -31,8 +31,11 @@ if [[ ${TRAVIS_PULL_REQUEST} == "false" ]] && [[ ${TRAVIS_BRANCH} == "master" ]]
 
     git commit -m "Built from ${REV}";
 
-    # Push it up
-    git push -q "https://${GH_TOKEN}@github.com/hawkowl/incremental.git" gh-pages
+    if [[ ${TRAVIS_REPO_SLUG} == "twisted/incremental" ]];
+    then
+      # Push it up
+      git push -q "https://${GH_TOKEN}@github.com/hawkowl/incremental.git" gh-pages
+    fi
 else
     echo "skipping docs upload"
 fi;


### PR DESCRIPTION
The git push phase of the `PUSH_DOCS` build job fails for forks, unsurprisingly due to authentication errors.

Example: https://travis-ci.org/hugovk/incremental/jobs/353536224

So if we're on a fork, do the docs build, but don't attempt to git push.

Example: https://travis-ci.org/hugovk/incremental/jobs/353544655