### PR TITLE
twisted has dropped python 3.4, and so shall we

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - python: 3.4
-      env: TOX_ENV=py34-tests
     - python: 3.5
       env: TOX_ENV=py35-tests
     - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py27,py35}-flake8,
-    {py27,pypy,py34,py35,py36}-tests,
+    {py27,pypy,py35,py36}-tests,
     check-manifest,
     apidocs
 


### PR DESCRIPTION
Fixes the broken master build.