### PR TITLE
Add short description to package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     },
     license="MIT",
     zip_safe=False,
+    description="A small library that versions your Python projects.",
     long_description=open('README.rst').read(),
     entry_points="""
     [distutils.setup_keywords]


### PR DESCRIPTION
Without this, the package summary reads "UNKNOWN", which stands out in [SoftFab's About page](https://softfab.io/sf/About).