### PR TITLE
Enable codecov.io PR comments.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 source =
        incremental
+       tests
 branch = True
 
 [paths]

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,8 @@
 [run]
-source =
-       incremental
-       tests
+# List of package names.
+source_pkgs = incremental
+# List of directory names.
+source = tests
 branch = True
 
 [paths]

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -32,10 +32,12 @@ coverage:
         threshold: 0.02%
 
 
-# We don't want to receive general PR comments about coverage.
-# We have the commit status checks and that should be enough.
 # See https://docs.codecov.io/docs/pull-request-comments
-comment: false
+comment:
+  layout: "header, diff, files"
+  behavior: default
+  require_changes: true  # if true: only post the comment if coverage changes
+
 
 # See https://docs.codecov.io/docs/github-checks
 github_checks:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -35,7 +35,6 @@ coverage:
         paths:
           - "src/incremental/tests/*"
           - "tests/*"
-          - "examplesetup.py"
 
 
 # See https://docs.codecov.io/docs/pull-request-comments

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -8,6 +8,15 @@
 codecov:
   require_ci_to_pass: yes
   notify:
+    # Wait a bit before pushing the status.
+    # The number here should be as close as possible to the total
+    # number of python supported versions.
+    # At the same time, if a Python version is removed this might
+    # accidentally cause disabling the coverage reporting as we will
+    # no longer have that many jobs.
+    # I have set it now to 3 to try to reduce as possible the temporary
+    # report for missing coverage.
+    after_n_builds: 3
     wait_for_ci: yes
 
 coverage:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -8,9 +8,6 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    # We have at least 10 builds in GitHub Actions and 12 in Azure
-    # and lint + mypy + docs + ReadTheDocs
-    after_n_builds: 15
     wait_for_ci: yes
 
 coverage:
@@ -30,6 +27,13 @@ coverage:
         # swinging coverage that is not triggered by changes in a PR.
         # See: https://twistedmatrix.com/trac/ticket/10170
         threshold: 0.02%
+      tests:
+        # Make sure we run each test at least once.
+        # If we don't have 100% coverage for tests, it meant that some
+        # tests are always skipped.
+        target: 100%
+        paths:
+          - "src/incremental/tests/*"
 
 
 # See https://docs.codecov.io/docs/pull-request-comments

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -34,6 +34,8 @@ coverage:
         target: 100%
         paths:
           - "src/incremental/tests/*"
+          - "tests/*"
+          - "examplesetup.py"
 
 
 # See https://docs.codecov.io/docs/pull-request-comments

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -8,15 +8,6 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    # Wait a bit before pushing the status.
-    # The number here should be as close as possible to the total
-    # number of python supported versions.
-    # At the same time, if a Python version is removed this might
-    # accidentally cause disabling the coverage reporting as we will
-    # no longer have that many jobs.
-    # I have set it now to 3 to try to reduce as possible the temporary
-    # report for missing coverage.
-    after_n_builds: 3
     wait_for_ci: yes
 
 coverage:


### PR DESCRIPTION
This is a quick PR to enable codecov.io PR comments.

This PR will not have a comment, and it is configured to only send if the coverage was changed.

The commit status for coverage was not enable...as due to an error, it  was configured to wait for 15 test job results ... we we don't have that many.

It also adds a separate check for the tests code to make sure it always has 100% and we don't accidentally always skip a code.

I have enabled py3.9 tests as required for a merge.
I have also enabled "Require conversation resolution before merging" to make sure comments are not accidentally ignored. 