### PR TITLE
Use official actions to publish the API docs

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -1,0 +1,29 @@
+name: Publish API docs
+
+outputs:
+  docs_url:
+    description: "Deployed URL"
+    value: ${{ steps.deployment.outputs.page_url }}/docs/
+
+runs:
+  using: "composite"
+
+  steps:
+
+  - name: Prepare GitHub Pages
+    run: |
+      mkdir website
+      cat >website/index.html <<!
+        <DOCTYPE html>
+        <meta http-equiv="refresh" content="0;URL=./docs/">
+        <a href="./docs/">Click here if not redirected</a>
+      !
+      mv apidocs website/docs
+    shell: bash
+
+  - uses: actions/upload-pages-artifact@v3
+    with:
+      path: website
+
+  - uses: actions/deploy-pages@v4
+    id: deployment

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,9 @@ on:
 
 permissions:
   contents: read
+  # Required to publish to Pages:
+  pages: write
+  id-token: write
 
 
 defaults:
@@ -82,22 +85,9 @@ jobs:
         # GitHub Actions VM have 2 CPUs.
         tox --parallel 2 --installpkg dist/*.whl
 
-    - name: Prepare GitHub Pages
+    - name: Publish API docs
       if: contains(matrix['tox-env'], 'apidocs')
-      run: |
-        mkdir website
-        touch website/index.html
-        mv apidocs website/docs
-
-    - name: Publish documentation for push on trunk
-      # Since we don't have a separate job for apidocs gh-pages updating
-      # hijack the normal apidoc test and publish the resulting files.
-      if: contains(matrix['tox-env'], 'apidocs') && github.event_name == 'push'
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        commit_message: Publish docs for ${{ github.sha }}
-        publish_dir: ./website
+      uses: ./.github/actions/publish-docs
 
     - name: Prepare coverage results
       if: ${{ !cancelled() && !matrix.skip-coverage }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,7 +86,7 @@ jobs:
         tox --parallel 2 --installpkg dist/*.whl
 
     - name: Publish API docs
-      if: contains(matrix['tox-env'], 'apidocs')
+      if: contains(matrix['tox-env'], 'apidocs') && github.ref == 'refs/heads/trunk'
       uses: ./.github/actions/publish-docs
 
     - name: Prepare coverage results


### PR DESCRIPTION
We can now [publish pages directly from actions](https://github.blog/news-insights/product-news/github-pages-now-uses-actions-by-default/) so I composed two official actions:

- [actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact?tab=readme-ov-file)
- [actions/deploy-pages](https://github.com/actions/deploy-pages)

I also:

- Switched the [Pages source](https://github.com/twisted/incremental/settings/pages) to GitHub Actions
- Ticked the "Enforce HTTPS" box
- Removed the [environment protection rule](https://github.com/twisted/incremental/settings/environments/2009403/edit) that allowed deploys from the gh-pages branch
- Unticked the "allow admins to bypass" box, since it appears to have allowed a deploy from this PR to go live (!)

Fixes #98.
