### PR TITLE
"A CalVer version manager that anticipates the future"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,23 @@ Incremental
 |gha|
 |coverage|
 
-Incremental is a small library that versions your Python projects.
+Incremental is a small library for versioning Python projects using `CalVer <https://calver.org/>`_.
 
 API documentation can be found `here <https://twisted.org/incremental/docs/>`_.
+Narrative documentation follows.
 
 .. contents::
+
+Theory of Operation
+-------------------
+
+- A version number has the form YY.MM.PATCH.
+- If your project is named "Shrubbery", its code is found in ``shrubbery/`` or ``src/shrubbery``.
+- Incremental stores your project's version number in ``{src/}shrubbery/_version.py``.
+- To update the version, run ``python -m incremental.update Shrubbery``, passing ``--rc`` and/or ``--patch`` as appropriate (see `Updating`_, below).
+- Changing the version also updates any `indeterminate versions`_ in your codebase, like "Shrubbery NEXT", so you can reference the upcoming release in documentation.
+
+In short: a CalVer version manager that lets you talk about the future.
 
 Quick Start
 -----------
@@ -157,6 +169,9 @@ The commands that can be given after that will determine what the next version i
 - ``--post``, to set the project postrelease number to 0 if it is not a postrelease, or bump the postrelease number by 1 if it is. This will also reset the release candidate and development release numbers.
 
 If you give no arguments, it will strip the release candidate number, making it a "full release".
+
+Indeterminate Versions
+----------------------
 
 Incremental supports "indeterminate" versions, as a stand-in for the next "full" version. This can be used when the version which will be displayed to the end-user is unknown (for example "introduced in" or "deprecated in"). Incremental supports the following indeterminate versions:
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
 Incremental
 ===========
 
-|gha|
 |pypi|
+|calver|
+|gha|
 |coverage|
 
 Incremental is a small library that versions your Python projects.
@@ -30,13 +31,13 @@ Add Incremental to your ``pyproject.toml``:
 
     [project]
     name = "<projectname>"
-    dynamic = ["version"]     # ← Mark the version dynamic
+    dynamic = ["version"]       # ← Mark the version dynamic
     dependencies = [
         "incremental>=24.7.2",  # ← Depend on incremental at runtime
     ]
     # ...
 
-    [tool.incremental]        # ← Activate Incremental's setuptools plugin
+    [tool.incremental]          # ← Activate Incremental's setuptools plugin
 
 It's fine if the ``[tool.incremental]`` table is empty, but it must be present.
 
@@ -61,14 +62,14 @@ activate Incremental's Hatchling plugin by altering your ``pyproject.toml``:
 
     [project]
     name = "<projectname>"
-    dynamic = ["version"]     # ← Mark the version dynamic
+    dynamic = ["version"]       # ← Mark the version dynamic
     dependencies = [
         "incremental>=24.7.2",  # ← Depend on incremental at runtime
     ]
     # ...
 
     [tool.hatch.version]
-    source = "incremental"    # ← Activate Incremental's Hatchling plugin
+    source = "incremental"      # ← Activate Incremental's Hatchling plugin
 
 Incremental can be configured as usual in an optional ``[tool.incremental]`` table.
 
@@ -173,11 +174,17 @@ Once the final version is made, it will become:
 - ``<projectname> 17.1.0``
 
 
-.. |coverage| image:: https://codecov.io/gh/twisted/incremental/branch/master/graph/badge.svg?token=K2ieeL887X
-.. _coverage: https://codecov.io/gh/twisted/incremental
+.. |pypi| image:: http://img.shields.io/pypi/v/incremental.svg
+    :alt: PyPI
+    :target: https://pypi.python.org/pypi/incremental
+
+.. |calver| image:: https://img.shields.io/badge/calver-YY.MM.MICRO-22bfda.svg
+    :alt: calver: YY.MM.MICRO
+    :target: https://calver.org/
 
 .. |gha| image:: https://github.com/twisted/incremental/actions/workflows/tests.yaml/badge.svg
-.. _gha: https://github.com/twisted/incremental/actions/workflows/tests.yaml
+    :alt: Tests
+    :target: https://github.com/twisted/incremental/actions/workflows/tests.yaml
 
-.. |pypi| image:: http://img.shields.io/pypi/v/incremental.svg
-.. _pypi: https://pypi.python.org/pypi/incremental
+.. |coverage| image:: https://img.shields.io/badge/Coverage-100%25-green
+    :alt: Coverage: 100%

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Incremental
 |gha|
 |coverage|
 
-Incremental is a small library for versioning Python projects using `CalVer <https://calver.org/>`_.
+Incremental is a `CalVer <https://calver.org/>`_ version manager supports the future.
 
 API documentation can be found `here <https://twisted.org/incremental/docs/>`_.
 Narrative documentation follows.
@@ -17,12 +17,12 @@ Theory of Operation
 -------------------
 
 - A version number has the form YY.MM.PATCH.
-- If your project is named "Shrubbery", its code is found in ``shrubbery/`` or ``src/shrubbery``.
+- If your project is named "Shrubbery", its code is found in ``shrubbery/`` or ``src/shrubbery/``.
 - Incremental stores your project's version number in ``{src/}shrubbery/_version.py``.
 - To update the version, run ``python -m incremental.update Shrubbery``, passing ``--rc`` and/or ``--patch`` as appropriate (see `Updating`_, below).
 - Changing the version also updates any `indeterminate versions`_ in your codebase, like "Shrubbery NEXT", so you can reference the upcoming release in documentation.
+  That's how Incremental supports the future.
 
-In short: a CalVer version manager that lets you talk about the future.
 
 Quick Start
 -----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ name = "incremental"
 dynamic = ["version"]
 maintainers = [
     {name = "Amber Brown", email = "hawkowl@twistedmatrix.com"},
+    {name = "Tom Most", email = "twm@freecog.net"},
 ]
 classifiers = [
     "Intended Audience :: Developers",
@@ -26,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.8"
-description = "A small library that versions your Python projects."
+description = "A small library for versioning Python projects using CalVer."
 readme = "README.rst"
 dependencies = [
     "setuptools >= 61.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.8"
-description = "A small library for versioning Python projects using CalVer."
+description = "A CalVer version manager that supports the future."
 readme = "README.rst"
 dependencies = [
     "setuptools >= 61.0",

--- a/src/incremental/newsfragments/2.doc
+++ b/src/incremental/newsfragments/2.doc
@@ -1,0 +1,1 @@
+Incremental's documentation now highlights its primary features: CalVer and indeterminate versions (NEXT).


### PR DESCRIPTION
This gives Incremental a new tagline:

> A CalVer version manager that anticipates the future.

This highlights Incremental's two primary features:

- It automates CalVer, of the YY.MM.PATCH variety
- It supports indeterminate versions (i.e. NEXT)

I added a set of bullet points high up in the readme that highlight what Incremental does. This was partially inspired by Versioneer's [theory of operation](https://github.com/python-versioneer/python-versioneer?tab=readme-ov-file#theory-of-operation).

-------

Add a preamble to the readme that clarifies Incremental's purpose. Fixes #2, hopefully.

Update the badges in the readme. Fixes #105.