### PR TITLE
Use packaging instead of pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.8"
 description = "A CalVer version manager that supports the future."
 readme = "README.rst"
 dependencies = [
-    "packaging",
+    "packaging >= 17.0",
     "tomli; python_version < '3.11'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.8"
 description = "A CalVer version manager that supports the future."
 readme = "README.rst"
 dependencies = [
-    "setuptools >= 61.0",
+    "packaging",
     "tomli; python_version < '3.11'",
 ]
 

--- a/src/incremental/newsfragments/141.feature.rst
+++ b/src/incremental/newsfragments/141.feature.rst
@@ -1,0 +1,1 @@
+Incremental now depends on packaging instead of setuptools at runtime

--- a/src/incremental/update.py
+++ b/src/incremental/update.py
@@ -81,7 +81,7 @@ def _run(
         from packaging.version import Version as parse_version
 
         existing = _existing_version(versionpath)
-        st_version = parse_version(newversion)._version
+        st_version = parse_version(newversion)
 
         release = list(st_version.release)
 
@@ -100,8 +100,8 @@ def _run(
             minor,
             micro,
             release_candidate=st_version.pre[1] if st_version.pre else None,
-            post=st_version.post[1] if st_version.post else None,
-            dev=st_version.dev[1] if st_version.dev else None,
+            post=st_version.post,
+            dev=st_version.dev,
         )
 
     elif create:

--- a/src/incremental/update.py
+++ b/src/incremental/update.py
@@ -78,7 +78,7 @@ def _run(
 
     versionpath = os.path.join(path, "_version.py")
     if newversion:
-        from pkg_resources import parse_version
+        from packaging.version import Version as parse_version
 
         existing = _existing_version(versionpath)
         st_version = parse_version(newversion)._version


### PR DESCRIPTION
As `pkg_resources.parse_version()` is now an alias for `packaging.version.Version`, use the latter directly. Also stop poking at underscore attributes in favor of public API.

Fixes #141.
