### PR TITLE
Update pre-commit config for ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,10 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.11.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.9
     hooks:
-      - id: pyupgrade
-        args:
-          - --keep-percent-format
-
-  - repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
-    hooks:
-      - id: flake8
-
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.2.2
-    hooks:
-      - id: yesqa
+      - id: ruff-check
+        args: [ --fix ]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ select = [
     "F",
     "UP",
     "I",
+    "RUF",
 ]
 ignore = [
     "E501",

--- a/src/incremental/__init__.py
+++ b/src/incremental/__init__.py
@@ -548,4 +548,4 @@ def _extract_tool_incremental(data: Dict[str, object]) -> Optional[Dict[str, obj
 
 from ._version import __version__  # noqa: E402
 
-__all__ = ["__version__", "Version", "getVersionString"]
+__all__ = ["Version", "__version__", "getVersionString"]

--- a/src/incremental/update.py
+++ b/src/incremental/update.py
@@ -48,31 +48,31 @@ def _run(
         path = _findPath(_getcwd(), package)
 
     if (
-        newversion
-        and patch
-        or newversion
-        and dev
-        or newversion
-        and rc
-        or newversion
-        and post
+        (newversion
+        and patch)
+        or (newversion
+        and dev)
+        or (newversion
+        and rc)
+        or (newversion
+        and post)
     ):
         raise ValueError("Only give --newversion")
 
-    if dev and patch or dev and rc or dev and post:
+    if (dev and patch) or (dev and rc) or (dev and post):
         raise ValueError("Only give --dev")
 
     if (
-        create
-        and dev
-        or create
-        and patch
-        or create
-        and rc
-        or create
-        and post
-        or create
-        and newversion
+        (create
+        and dev)
+        or (create
+        and patch)
+        or (create
+        and rc)
+        or (create
+        and post)
+        or (create
+        and newversion)
     ):
         raise ValueError("Only give --create")
 

--- a/src/incremental/update.py
+++ b/src/incremental/update.py
@@ -48,14 +48,10 @@ def _run(
         path = _findPath(_getcwd(), package)
 
     if (
-        (newversion
-        and patch)
-        or (newversion
-        and dev)
-        or (newversion
-        and rc)
-        or (newversion
-        and post)
+        (newversion and patch)
+        or (newversion and dev)
+        or (newversion and rc)
+        or (newversion and post)
     ):
         raise ValueError("Only give --newversion")
 
@@ -63,16 +59,11 @@ def _run(
         raise ValueError("Only give --dev")
 
     if (
-        (create
-        and dev)
-        or (create
-        and patch)
-        or (create
-        and rc)
-        or (create
-        and post)
-        or (create
-        and newversion)
+        (create and dev)
+        or (create and patch)
+        or (create and rc)
+        or (create and post)
+        or (create and newversion)
     ):
         raise ValueError("Only give --create")
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -10,11 +10,11 @@ from importlib import metadata
 from subprocess import run
 from tempfile import TemporaryDirectory
 
+from build import BuildBackendException, ProjectBuilder
+from build.env import DefaultIsolatedEnv
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import TestCase
 
-from build import BuildBackendException, ProjectBuilder
-from build.env import DefaultIsolatedEnv
 from incremental import Version
 
 TEST_DIR = FilePath(os.path.abspath(os.path.dirname(__file__)))


### PR DESCRIPTION
Update the pre-commit configuration to invoke [ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit?tab=readme-ov-file) rather than various other tools.

Also update Ruff's configuration to enable [`RUF` rules](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf), which include [RUF100](https://docs.astral.sh/ruff/rules/unused-noqa/), replacing `yesqa`.

Closes #168.
