### PR TITLE
Add Python 3.13 and 3.14; drop 3.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
         # When updating the minimum Python version here, also update the
         # `python_requires` from `setup.cfg`.
         # Run on latest minor release of each major python version.
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
         tox-env: ['tests']
 
         include:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
         # When updating the minimum Python version here, also update the
         # `python_requires` from `setup.cfg`.
         # Run on latest minor release of each major python version.
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
         tox-env: ['tests']
 
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">=3.8"
 description = "A CalVer version manager that supports the future."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Framework :: Hatch",
     "Framework :: Setuptools Plugin",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/requirements_mypy.txt
+++ b/requirements_mypy.txt
@@ -14,7 +14,7 @@ hatchling==1.27.0
     # via -r requirements_mypy.in
 hyperlink==21.0.0
     # via twisted
-idna==3.7
+idna==3.11
     # via hyperlink
 incremental==24.7.2
     # via twisted

--- a/requirements_mypy.txt
+++ b/requirements_mypy.txt
@@ -44,7 +44,7 @@ typing-extensions==4.12.2
     #   automat
     #   mypy
     #   twisted
-zope-interface==6.4.post2
+zope-interface==8.0.1
     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -42,7 +42,7 @@ filelock==3.15.4
     # via virtualenv
 h11==0.14.0
     # via httpcore
-hatch==1.14.1
+hatch==1.15.1
     # via -r requirements_tests.in
 hatchling==1.27.0
     # via hatch

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -142,7 +142,7 @@ virtualenv==20.28.0
     # via hatch
 zipp==3.19.2
     # via importlib-metadata
-zope-interface==6.4.post2
+zope-interface==8.0.1
     # via twisted
 zstandard==0.25.0
     # via hatch

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -18,7 +18,7 @@ certifi==2024.7.4
     # via
     #   httpcore
     #   httpx
-cffi==1.16.0
+cffi==2.0.0
     # via cryptography
 click==8.1.7
     # via

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -14,7 +14,7 @@ backports-tarfile==1.2.0
     # via jaraco-context
 build==1.2.2.post1
     # via -r requirements_tests.in
-certifi==2024.7.4
+certifi==2025.10.5
     # via
     #   httpcore
     #   httpx
@@ -32,7 +32,7 @@ coverage==7.5.4
     #   coverage-p
 coverage-p==25.2.0
     # via -r requirements_tests.in
-cryptography==44.0.1
+cryptography==45.0.7
     # via secretstorage
 distlib==0.3.8
     # via virtualenv
@@ -40,21 +40,21 @@ exceptiongroup==1.2.1
     # via anyio
 filelock==3.15.4
     # via virtualenv
-h11==0.14.0
+h11==0.16.0
     # via httpcore
 hatch==1.15.1
     # via -r requirements_tests.in
 hatchling==1.27.0
     # via hatch
-httpcore==1.0.5
+httpcore==1.0.9
     # via httpx
-httpx==0.27.0
+httpx==0.28.1
     # via hatch
 hyperlink==21.0.0
     # via
     #   hatch
     #   twisted
-idna==3.7
+idna==3.11
     # via
     #   anyio
     #   httpx
@@ -115,9 +115,7 @@ secretstorage==3.3.3
 shellingham==1.5.4
     # via hatch
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 tomli==2.0.1
     # via
     #   build

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -146,7 +146,7 @@ zipp==3.19.2
     # via importlib-metadata
 zope-interface==6.4.post2
     # via twisted
-zstandard==0.22.0
+zstandard==0.25.0
     # via hatch
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/src/incremental/newsfragments/179.feature.rst
+++ b/src/incremental/newsfragments/179.feature.rst
@@ -1,0 +1,1 @@
+Add Python 3.13 and 3.14 to the test matrix.

--- a/src/incremental/newsfragments/179.removal.rst
+++ b/src/incremental/newsfragments/179.removal.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.8, which has been end-of-life since October 2024.


### PR DESCRIPTION
- Add Python 3.13 and 3.14 to the test matrix
- Update pinned dependencies as necessary to get the build to pass
- Remove Python 3.8 because test dependencies have dropped it

There are no code changes that would prevent Incremental from working on Python 3.8, so I haven't adjusted the `requires_python`, but it's no longer considered supported.